### PR TITLE
Update package.json

### DIFF
--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -22,10 +22,10 @@
 		"create:block" : "node ./bin/compiler.js block",
 		"dump" : "node ./bin/compiler.js dump",
 		"lint" : "npm run lint:js && npm run lint:css",
-		"lint:css" : "wp-scripts lint-style ./src/**/*.scss",
-		"lint:js": "wp-scripts lint-js ./src",
+		"lint:css" : "wp-scripts lint-style './src/**/*.scss'",
+		"lint:js": "wp-scripts lint-js './src/**/*.js'",
 		"imagemin" : "node ./bin/imagemin.mjs src/image build/image",
-		"format:js": "wp-scripts format-js ./src",
+		"format:js": "wp-scripts format-js './src/**/*.js'",
 		"lib:normalize": "postcss ./node_modules/normalize.css/normalize.css --dir ./build/vendor",
 		"watch" : "npm-watch"
 	},


### PR DESCRIPTION
glob needs quotaions.

> When you run commands similar to the npm run lint:css:src example above, be sure to include the quotation marks around file globs. This ensures that you can use the powers of globby (like the ** globstar) regardless of your shell. See more examples.

## 変更内容

Add quotation to package.json. Glob needs single quotes.

## 関連イシュー・URL

https://www.npmjs.com/package/@wordpress/scripts

## 変更の種類
<!-- 該当する項目に x を入れてください -->
- [x] バグ修正
- [x] 機能改善

