### PR TITLE
Add code coverage option to wp-unit-test.yml

### DIFF
--- a/.github/workflows/wp-unit-test.yml
+++ b/.github/workflows/wp-unit-test.yml
@@ -93,11 +93,13 @@ jobs:
       - name: Output coverage to Job Summary
         if: ${{ inputs.coverage && always() }}
         run: |
-          echo '## Code Coverage Report' >> $GITHUB_STEP_SUMMARY
-          echo '' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          grep -A 999 'Code Coverage Report:' coverage-output.txt >> $GITHUB_STEP_SUMMARY || echo 'No coverage data' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+          {
+            echo '## Code Coverage Report'
+            echo ''
+            echo '```'
+            grep -A 999 'Code Coverage Report:' coverage-output.txt || echo 'No coverage data'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload coverage artifact
         if: ${{ inputs.coverage }}


### PR DESCRIPTION
## Summary

Closes #77

- `coverage` boolean input を追加（デフォルト `false`、既存動作に影響なし）
- coverage 有効時に `shivammathur/setup-php` で pcov を有効化
- テスト実行を分岐し、coverage 有効時は `--coverage-text --coverage-clover=coverage.xml` 付きで実行
- カバレッジレポートを GitHub Job Summary に出力
- `coverage.xml` を artifact としてアップロード（7日間保持、将来の Codecov 連携用）

## 呼び出し側の使い方

```yaml
uses: tarosky/workflows/.github/workflows/wp-unit-test.yml@main
with:
  php_version: '8.0'
  wp_version: 'latest'
  coverage: true
```

呼び出し側の `phpunit.xml.dist` に `<coverage>` セクションが必要です。

## Test plan

- [ ] `coverage: false`（デフォルト）で既存のテストが変わらず動作すること
- [ ] `coverage: true` でカバレッジレポートが Job Summary に表示されること
- [ ] `coverage.xml` が artifact としてアップロードされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)