### PR TITLE
Add shared Claude Code review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -4,11 +4,11 @@ on:
   workflow_call:
     inputs:
       plugin_name:
-        description: プラグイン名（例: rich-taxonomy）
+        description: "プラグイン名（例: rich-taxonomy）"
         required: true
         type: string
       ci_checks:
-        description: CI で実行済みのチェック（例: "PHPStan Level 5, PHPCS, PHPUnit, asset build"）
+        description: 'CI で実行済みのチェック（例: PHPStan Level 5, PHPCS, PHPUnit, asset build）'
         required: true
         type: string
       pr_number:


### PR DESCRIPTION
## Summary
- タロスカイ全プラグイン共通の AI コードレビュー共有ワークフローを追加
- 各プラグインは薄いラッパー（`claude-review.yml`）から `workflow_call` で呼び出す
- レビューロジック、ラベル付与、出力フォーマットを一元管理

## 機能
- **自動ラベル付与**: `risk:low/medium/high`, `scope:*`, `needs-*`, `ai-triaged`
- **テスト要否分析**: 新規関数・バグ修正・REST API等のルールベース判定
- **セキュリティ**: PR内容からのプロンプトインジェクション対策
- **日本語出力**: トリアージサマリー + 詳細レビューの2層構造
- **カスタマイズ**: `custom_focus` input でプラグイン固有の観点を追加可能

## Inputs
| Input | Required | Description |
|-------|----------|-------------|
| `plugin_name` | Yes | プラグイン名 |
| `ci_checks` | Yes | CI で実行済みのチェック |
| `pr_number` | Yes | PR番号 |
| `head_sha` | Yes | レビュー対象のコミットSHA |
| `custom_focus` | No | プラグイン固有のレビュー観点 |
| `model` | No | Claude モデル（default: claude-sonnet-4-6） |

## Test plan
- [ ] rich-taxonomy でテストPRを作成し、auto-review が発火することを確認
- [ ] ラベルが正しく付与されるか確認
- [ ] 出力フォーマットが期待通りか確認
- [ ] `@claude` コメントで手動レビューが動くか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)