### PR TITLE
Fix deprecated set-output warnings by updating actions

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -28,12 +28,19 @@ jobs:
   pull-request:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: pull-request
-        uses: repo-sync/pull-request@v2
-        with:
-          destination_branch: ${{ inputs.destination_branch }}
-          pr_title: ${{ inputs.pr_title }}
-          pr_body: ${{ inputs.pr_body }}
-          pr_label: ${{ inputs.pr_label }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Check if PR already exists
+          EXISTING=$(gh pr list --base "${{ inputs.destination_branch }}" --head "${{ github.ref_name }}" --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "PR #${EXISTING} already exists, skipping."
+            exit 0
+          fi
+          gh pr create \
+            --base "${{ inputs.destination_branch }}" \
+            --title "${{ inputs.pr_title }}" \
+            --body "${{ inputs.pr_body }}" \
+            --label "${{ inputs.pr_label }}"

--- a/.github/workflows/backlog.yml
+++ b/.github/workflows/backlog.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send Notification to Backlog
-        uses: bicstone/backlog-notify@master
-        env:
-          PROJECT_KEY: ${{ inputs.project }}
-          API_HOST: ${{ inputs.host }}
-          API_KEY: ${{ secrets.BACKLOG_API_KEY }}
+        uses: bicstone/backlog-notify@v6
+        with:
+          project_key: ${{ inputs.project }}
+          api_host: ${{ inputs.host }}
+          api_key: ${{ secrets.BACKLOG_API_KEY }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,12 +15,12 @@ jobs:
     name: Yaml Syntax Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v4
 
       - name: Install Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '22'
 
       - name: Check Yaml Syntax
         run: |
@@ -39,13 +39,13 @@ jobs:
     name: Generate readme.txt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v4
 
       - uses: ./actions/wp-readme
 
       - name: Check file existence.
         id: check_files
-        uses: andstor/file-existence-action@v1
+        uses: andstor/file-existence-action@v3
         with:
           files: "readme.txt"
 
@@ -58,7 +58,7 @@ jobs:
     name: Version really changed?
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v4
 
       - uses: ./actions/versioning
         with:

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -31,7 +31,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working_directory }}
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
 
       - name: Install Node
         uses: actions/setup-node@v4

--- a/.github/workflows/php-short-open-tag.yml
+++ b/.github/workflows/php-short-open-tag.yml
@@ -53,7 +53,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working_directory }}
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v4
 
       - name: Setup PHP with composer
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -26,7 +26,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working_directory }}
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
 
       - name: Setup PHP with composer
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/phplint.yml
+++ b/.github/workflows/phplint.yml
@@ -56,7 +56,7 @@ jobs:
       matrix:
         php: ${{ fromJSON(inputs.php_versions) }}
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v4
 
       - name: Setup PHP with composer
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/wp-unit-test.yml
+++ b/.github/workflows/wp-unit-test.yml
@@ -49,7 +49,7 @@ jobs:
         env:
           MYSQL_ROOT_PASSWORD: root
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
 
       # ubuntu-latest requires subversion.
       # see: https://github.com/10up/action-wordpress-plugin-deploy/releases/tag/2.3.0

--- a/actions/distignore/action.yml
+++ b/actions/distignore/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - name: Add Prefix
       id: check_files
-      uses: andstor/file-existence-action@v1
+      uses: andstor/file-existence-action@v3
       with:
         files: ".distignore"
 

--- a/actions/versioning/action.yml
+++ b/actions/versioning/action.yml
@@ -17,7 +17,7 @@ runs:
   steps:
     - name: Check file existence.
       id: check_files
-      uses: andstor/file-existence-action@v1
+      uses: andstor/file-existence-action@v3
       with:
         files: ${{ inputs.files }}
 


### PR DESCRIPTION
## Summary

- `andstor/file-existence-action@v1` → `@v3` — v1が内部で `set-output` を使っており、主原因
- `bicstone/backlog-notify@master` → `@v6` — env変数からinputsに移行
- `actions/checkout@master`/`@main`/`@v2` → `@v4` — 全ワークフロー統一
- `actions/setup-node@v3` → `@v4`、Node 16 → 22（lint.yml）
- `repo-sync/pull-request@v2` → `gh pr create`（リポジトリがアーカイブ済み）

## Test plan

- [x] lint.yml の CI（YAML syntax, readme, versioning, phplint, php-short-open-tag）が通ること
- [x] backlog.yml の inputs が正しく渡されること（呼び出し側で確認）
- [x] auto-pr.yml の `gh pr create` が既存PR重複チェック含め動作すること

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)