### PR TITLE
auto-review: skip clean merge-only commits

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -29,6 +29,11 @@ on:
         required: false
         type: string
         default: 'claude-sonnet-4-6'
+      is_manual:
+        description: 手動トリガー（@claude auto-review 等）から呼び出された場合は true。merge-only コミットでもレビューを実行する。
+        required: false
+        type: boolean
+        default: false
     secrets:
       ANTHROPIC_API_KEY:
         required: true
@@ -61,8 +66,29 @@ jobs:
             gh label create "$label" --force 2>/dev/null || true
           done
 
+      - name: Check meaningful diff
+        id: diff-check
+        run: |
+          if [ "${{ inputs.is_manual }}" = "true" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Manual trigger; running review regardless of diff."
+            exit 0
+          fi
+          parents=$(git rev-list --parents -n 1 "${{ inputs.head_sha }}" | awk '{print NF-1}')
+          if [ "$parents" -ge 2 ]; then
+            cc_output=$(git diff-tree --cc "${{ inputs.head_sha }}")
+            if [ -z "$cc_output" ]; then
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              echo "::notice::Clean merge commit (no manual edits); skipping review."
+              exit 0
+            fi
+            echo "::notice::Merge commit with manual edits; running review."
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
       - name: Fetch previous AI review comments
         id: previous-reviews
+        if: steps.diff-check.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -80,6 +106,7 @@ jobs:
           fi
 
       - name: Run Claude Code Review
+        if: steps.diff-check.outputs.skip != 'true'
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary

- `claude-review.yml` 共有ワークフローに `is_manual` インプットを追加し、auto-review (workflow_run トリガー) でクリーンな merge-only コミットをスキップする preflight ステップを実装
- 手動トリガー (`@claude auto-review` 等) で `is_manual: true` を渡された場合は常にレビューを実行する

## 背景

外部パートナー PR の運用で、`main` からのマージ・準備コミットなど **実質的な変更を含まない merge コミット** に対して Claude がレビューを投稿してノイズになっていた（例: tarosky/motorfan-content#758 で merge-only コミットに対して複数のレビュー投稿が発生）。Anthropic API コストも無駄に発生していた。

## 検出ロジック

1. `is_manual == true` なら常にレビュー実行（手動の意思を尊重）
2. それ以外で、HEAD の親が2つ以上（merge コミット）かつ `git diff-tree --cc <head_sha>` の出力が空（両親と異なる手動編集なし＝クリーンマージ）→ スキップ
3. それ以外（通常コミット、コンフリクト解決を含むマージ）→ レビュー実行

`git diff-tree --cc` は両親と異なる内容を持つ箇所のみ出力するため、コンフリクト解決の手動編集が含まれる場合は出力が空にならず、レビューが走る設計。

## 利用側の対応

- 共有側のデフォルトは `is_manual: false` のため、利用側未更新でも auto-review のスキップは即時有効
- 利用側（rich-taxonomy など 11 プラグイン）の `manual-review` job に `is_manual: true` を追加する作業は別 PR で対応予定

## Test plan

- [x] このリポジトリ自体には `claude-review.yml` を `workflow_run` で呼ぶ self 設定がないため、本 PR 上で merge-only スキップは発火しない（`@claude` アシスタント応答は可能）
- [ ] マージ後、ダウンストリーム plugin の次回 PR で挙動確認:
  - 通常コミット → レビュー実行（従来通り）
  - main からのクリーンマージ → スキップ（workflow run の notice で確認）
  - コンフリクト解決を含むマージ → レビュー実行
- [ ] 手動 `@claude auto-review` の挙動は利用側へ `is_manual: true` を反映した別 PR 後に検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)