### PR TITLE
Node 20非推奨アクションを一括更新

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -28,7 +28,7 @@ jobs:
   pull-request:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: pull-request
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-tag-in-branch.yml
+++ b/.github/workflows/check-tag-in-branch.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # 必ずフル履歴を取得する
           ref: ${{ inputs.allowed_branch }}

--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -32,7 +32,7 @@ jobs:
       github.event.comment.author_association == 'COLLABORATOR'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run Claude Assistant
         uses: anthropics/claude-code-action@v1

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.head_sha }}
           fetch-depth: 0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,10 +15,10 @@ jobs:
     name: Yaml Syntax Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 
@@ -39,7 +39,7 @@ jobs:
     name: Generate readme.txt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./actions/wp-readme
 
@@ -58,7 +58,7 @@ jobs:
     name: Version really changed?
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./actions/versioning
         with:

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -31,10 +31,10 @@ jobs:
       run:
         working-directory: ${{ inputs.working_directory }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node_version || '' }}
           node-version-file: ${{ inputs.node_version && '' || '.node-version' }}

--- a/.github/workflows/php-short-open-tag.yml
+++ b/.github/workflows/php-short-open-tag.yml
@@ -53,7 +53,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working_directory }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup PHP with composer
         uses: shivammathur/setup-php@v2
@@ -68,7 +68,7 @@ jobs:
         run: ${{ inputs.install_command }}
 
       - name: Search Short Open tags
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         id: short-open-tags
         with:
           result-encoding: string

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -26,7 +26,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working_directory }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup PHP with composer
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/phplint.yml
+++ b/.github/workflows/phplint.yml
@@ -56,7 +56,7 @@ jobs:
       matrix:
         php: ${{ fromJSON(inputs.php_versions) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup PHP with composer
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/playground-preview-build.yml
+++ b/.github/workflows/playground-preview-build.yml
@@ -36,7 +36,7 @@ jobs:
     env:
       PLUGIN_SLUG: ${{ inputs.plugin_slug || github.event.repository.name }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -47,7 +47,7 @@ jobs:
           tools: composer
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node_version || '' }}
           node-version-file: ${{ inputs.node_version && '' || '.node-version' }}
@@ -62,7 +62,7 @@ jobs:
           cd plugin-build && zip -r ../${{ env.PLUGIN_SLUG }}.zip .
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: playground-pr${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
           path: ${{ env.PLUGIN_SLUG }}.zip

--- a/.github/workflows/playground-preview-publish.yml
+++ b/.github/workflows/playground-preview-publish.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Extract PR metadata from artifact
         id: metadata
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const artifacts = await github.rest.actions.listWorkflowRunArtifacts({

--- a/.github/workflows/sync-issues-to-project.yml
+++ b/.github/workflows/sync-issues-to-project.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Sync issues to organization project
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.PROJECT_SYNC_PAT }}
           script: |

--- a/.github/workflows/wp-unit-test.yml
+++ b/.github/workflows/wp-unit-test.yml
@@ -49,7 +49,7 @@ jobs:
         env:
           MYSQL_ROOT_PASSWORD: root
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # ubuntu-latest requires subversion.
       # see: https://github.com/10up/action-wordpress-plugin-deploy/releases/tag/2.3.0
@@ -103,7 +103,7 @@ jobs:
 
       - name: Upload coverage artifact
         if: ${{ inputs.coverage }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-report
           path: coverage.xml


### PR DESCRIPTION
## 概要

GitHub ActionsのNode 20ランタイムが非推奨化(2026/6/16からNode 24強制、9/16にランナーから削除)。本リポジトリの共有ワークフローが各利用リポジトリで警告を発生させているため、一括更新する。

実例: fumikito/kyom のリリースで `check-tag-in-branch.yml` 経由の警告を確認。

## 変更内容(21箇所 / 13ファイル)

| アクション | 変更 | 備考 |
|---|---|---|
| `actions/checkout` | v4 → **v6** (×13) | |
| `actions/setup-node` | v4 → **v6** (×3) | インストールするNodeバージョン指定は不変 |
| `actions/github-script` | v7 → **v8** (×3) | **v9は意図的に回避**: ESM化で `require()` に破壊的変更があり、php-short-open-tag.yml が `require('fs')` を使用しているため。v8はNode 24対応のみで安全 |
| `actions/upload-artifact` | v4 → **v6** (×2) | v6がNode 24対応の安定版。v7(ESM化+新機能)は見送り |

## 対象外(変更なし)

- `shivammathur/setup-php@v2`, `anthropics/claude-code-action@v1` など: メンテされているムービングタグ
- `actions/wp-readme`, `actions/versioning`, `actions/distignore`: すべてcomposite actionでNodeランタイム非依存
- `plugin-audit.yml` のshellcheck指摘: 既存の問題で本PRとは無関係

## 影響範囲

- 全ワークフローが `ubuntu-latest`(GitHub-hosted)のみで、Node 24の最低ランナー要件(2.327.1)は常に満たされる。self-hostedランナーの使用なし
- `@main` 参照のため、マージ後すぐ全利用リポジトリに反映される

## 検証

- `actionlint` で変更13ファイルすべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)