### PR TITLE
watchtower-notify に slug input を追加 (#110)

### DIFF
--- a/.github/workflows/watchtower-notify.yml
+++ b/.github/workflows/watchtower-notify.yml
@@ -14,6 +14,12 @@ on:
         description: OIDC token の audience（watchtower 側 WATCHTOWER_OIDC_AUDIENCE と一致させる）
         type: string
         default: watchtower
+      slug:
+        description: |
+          プラグイン slug（シート H列）。リポ名と異なる / monorepo の場合に指定。
+          未指定ならリポ名（repository クレーム由来）が使われる。
+        type: string
+        default: ''
 
 jobs:
   notify:
@@ -27,6 +33,7 @@ jobs:
           ENDPOINT: ${{ inputs.endpoint }}
           AUDIENCE: ${{ inputs.audience }}
           VERSION: ${{ github.event.release.tag_name }}
+          SLUG: ${{ inputs.slug }}
         run: |
           set -euo pipefail
 
@@ -42,7 +49,12 @@ jobs:
 
           # 2. watchtower へ通知。プラグイン名はトークンの repository クレームから
           #    watchtower 側で導出されるため、body には version(tag) だけ送る。
-          PAYLOAD=$(jq -nc --arg v "$VERSION" '{version:$v}')
+          #    slug を指定した場合（リポ名 ≠ プラグイン slug / monorepo）は body に含める。
+          if [ -n "$SLUG" ]; then
+            PAYLOAD=$(jq -nc --arg v "$VERSION" --arg s "$SLUG" '{version:$v, slug:$s}')
+          else
+            PAYLOAD=$(jq -nc --arg v "$VERSION" '{version:$v}')
+          fi
           HTTP_CODE=$(curl -sS -o /tmp/resp.json -w '%{http_code}' \
             -X POST "$ENDPOINT" \
             -H "Authorization: Bearer $TOKEN" \


### PR DESCRIPTION
## 概要

reusable workflow \`watchtower-notify.yml\` に **\`slug\` input** を追加し、watchtower への通知 body に条件付きで含める。Closes #110

## 背景

watchtower は照合の起点 slug を OIDC トークンの \`repository\` クレームから決め打ちしている（\`tarosky/kestrel\` → \`kestrel\`）。このため **リポ名 ≠ プラグイン slug**（例: \`tarosky/kestrel\` の中身が \`kestrel-wp\`）や monorepo を照合できず、通知が 0 件で静かに無視される。watchtower 側は body の \`slug\` を受理済み（tarosky/watchtower#10）。

## 変更点

- \`workflow_call.inputs\` に \`slug\`（\`type: string\`, default \`''\`）を追加
- 通知ステップで \`SLUG\` を env に渡し、payload を分岐
  - \`slug\` 指定時: \`{version, slug}\`
  - 未指定時: \`{version}\`（従来どおり）
- Wiki ドキュメント（別リポ）も更新済み

## 完了条件

- [x] \`slug\` input 追加（default \`''\`、未指定時は従来挙動）
- [x] payload に slug を条件付きで含める
- [x] 既存呼び出し（slug 未指定）の挙動が変わらないこと

## 関連
- tarosky/watchtower#10（watchtower 側で body.slug を受理）
- tarosky/kestrel 側で \`with: { slug: kestrel-wp }\` を指定（別イシュー）