### PR TITLE
fix: claude-review の /review コマンドを削除

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -111,8 +111,6 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
-            /review
-
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ inputs.pr_number }}
 


### PR DESCRIPTION
## 概要

Claude Code v2.1.186 のリリースで `/review` コマンドの動作が変更されたため、オートレビューが失敗するようになった問題を修正します。

## 原因

- v2.1.186 で `/review` が `/code-review` エンジンに委譲されるよう変更された
- 非インタラクティブな SDK モード（CI）では、プロンプト先頭の `/review` が即エラーになる
- `claude-code-action@v1` が内部でインストールする Claude Code が v2.1.181 → v2.1.195 に上がったことで発現

## 修正内容

`prompt:` の先頭にあった `/review`（と直後の空行）を削除。

```diff
-            /review
-
             REPO: ${{ github.repository }}
```

## 確認方法

修正後、PRに対してオートレビューが正常に動作することを確認する。

by Claude