### PR TITLE
feat: Playground プレビューのホスティング用リリースを自動公開

### DIFF
--- a/.github/workflows/playground-preview-publish.yml
+++ b/.github/workflows/playground-preview-publish.yml
@@ -13,6 +13,20 @@ on:
         default: '2'
         required: false
         type: string
+      release_tag:
+        description: 'GitHub release tag used to host preview ZIPs'
+        default: 'ci-artifacts'
+        required: false
+        type: string
+      keep_release_draft:
+        description: >
+          Keep the hosting release as a draft. Draft releases are NOT publicly
+          downloadable, so WordPress Playground cannot fetch the ZIP. Leave false
+          (default) to publish the release so the preview URL works. Set true only
+          if the ZIP is served through another public path.
+        default: false
+        required: false
+        type: boolean
 
 jobs:
   publish:
@@ -58,6 +72,19 @@ jobs:
           commit-sha: ${{ steps.metadata.outputs.commit-sha }}
           artifact-source-run-id: ${{ github.event.workflow_run.id }}
           artifacts-to-keep: ${{ inputs.artifacts_to_keep }}
+          release-tag: ${{ inputs.release_tag }}
+
+      # The upstream expose action creates the hosting release as a draft, and
+      # draft release assets return 404 to anonymous downloads — so Playground
+      # cannot fetch the ZIP. Publish it (idempotent) unless the caller opts out.
+      - name: Publish hosting release
+        if: steps.metadata.outputs.found == 'true' && !inputs.keep_release_draft
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release edit "${{ inputs.release_tag }}" \
+            --repo "${{ github.repository }}" \
+            --draft=false
 
       - name: Generate blueprint
         if: steps.metadata.outputs.found == 'true'


### PR DESCRIPTION
## 背景

hamelp で Playground プレビューが参照できない事象を調査したところ、`expose-artifact-on-public-url`（`WordPress/action-wp-playground-pr-preview`）が ZIP をホストする `ci-artifacts` リリースを **`--draft` で作成**していることが原因と判明した。

draft リリースのアセットは匿名アクセスで 404 になるため、ブラウザ上で動く WordPress Playground が ZIP を取得できない。

実際に hamelp では以下のタイムラインを確認：
- `createdAt`: 今日 06:55（アクションが draft で作成）
- `publishedAt`: 今日 09:48（手動 publish）
- → この 06:55〜09:48 の間、Playground はアセットを 404 で取得できていなかった

## 変更内容

- expose ステップの後に **ホスティング用リリースを自動公開**するステップを追加（`gh release edit <tag> --draft=false`、冪等）
- upstream が draft にしている理由（releases 一覧の汚染・watcher への通知）を尊重し、`keep_release_draft`（デフォルト `false`）で従来の draft 維持も選べるようにした
- `release_tag` を input 化（デフォルト `ci-artifacts`）し、expose アクションにも渡すよう統一

## 影響

- 呼び出し側（hamelp 等）は変更不要。デフォルトで公開されるようになる
- 既存の公開済みリリースには影響なし（`--draft=false` は冪等）
- `@main` 参照の全プラグインに反映される

## 検証

- YAML 構文チェック済み
- `!inputs.keep_release_draft` は boolean input で正しく評価される
- reusable workflow の実地検証は merge 後の次回 Playground PR で確認予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)