### PR TITLE
feat: bot 起点 PR でも自動レビューを許可 (allowed_bots)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -34,6 +34,14 @@ on:
         required: false
         type: boolean
         default: false
+      allowed_bots:
+        description: >
+          claude-code-action の bot ガードで許可する bot ユーザー名（カンマ区切り、'*' で全 bot 許可）。
+          Claude Tag（Slack から PR 作成）など bot 起点の PR でも自動レビューを走らせるための設定。
+          デフォルトで claude を許可する。呼び出し側で fork は除外済みのため surface は限定的。
+        required: false
+        type: string
+        default: 'claude'
     secrets:
       ANTHROPIC_API_KEY:
         required: true
@@ -125,6 +133,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_bots: ${{ inputs.allowed_bots }}
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ inputs.pr_number }}


### PR DESCRIPTION
## 背景

Claude Tag（Slack から PR を作成する機能）で作られた PR で、CI 通過後の自動レビューが失敗していた。

原因は auto-review 側のフィルタではなく、`anthropics/claude-code-action@v1` の bot ガード：

\`\`\`
Action failed with error: Workflow initiated by non-human actor: claude (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
\`\`\`

（例: https://github.com/tarosky/hamelp/actions/runs/29492545366/job/87601887395 — auto-review ジョブは起動し、`Run Claude Code Review` ステップで失敗）

action は bot 起点のワークフローを既定で拒否する（bot ループ防止）。actor 判定は `allowed_bots` を小文字化＋`[bot]` 除去して比較するため、`claude` を許可すればよい。

## 変更内容

- reusable `claude-review.yml` に `allowed_bots` 入力を追加（デフォルト `claude`）
- `anthropics/claude-code-action@v1` に `allowed_bots: \${{ inputs.allowed_bots }}` を渡す

## 影響 / 安全性

- `@main` を参照する全プラグインで、Claude Tag 由来 PR の自動レビューが動くようになる（呼び出し側の変更は不要）
- caller 側で fork（`head_repository != github.repository`）は除外済み。actor login は GitHub 付与で詐称不可。許可対象は「当該リポにインストールされた claude bot が push した同一リポ PR」に限定される
- より広く許可したい場合は呼び出し側で `allowed_bots: '*'` 等を指定可能（public repo での `'*'` 警告は wiki に明記）

## 検証

- claude-code-action の `src/github/validation/actor.ts` の判定ロジックを確認し、`allowed_bots: "claude"` が正規化後 `claude` と一致することを確認済み
- YAML 構文チェック済み
- 実地検証は merge 後、Claude Tag 由来 PR の次回 CI 完了時に確認予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)